### PR TITLE
Fix artifact action deprecation

### DIFF
--- a/.github/workflows/build_pdf.yml
+++ b/.github/workflows/build_pdf.yml
@@ -27,7 +27,7 @@ jobs:
             --toc \
             -V CJKmainfont=NotoSansCJKjp-Regular
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: book-pdf
           path: build/book.pdf


### PR DESCRIPTION
## Summary
- update deprecated actions/upload-artifact version to v4

## Testing
- `grep -n "upload-artifact" -n .github/workflows/build_pdf.yml`
