### PR TITLE
Add tag input for manual release workflow

### DIFF
--- a/.github/workflows/build_pdf.yml
+++ b/.github/workflows/build_pdf.yml
@@ -6,6 +6,11 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Release tag (e.g. v1.0.0)'
+        required: true
+        type: string
 
 jobs:
   build:
@@ -35,5 +40,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: build/book.pdf
+          tag_name: ${{ github.event.inputs.tag_name || github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- allow specifying a tag when running the PDF build workflow manually
- pass that tag to `softprops/action-gh-release`

## Testing
- `pytest -q` *(fails: command not found)*