### PR TITLE
Fix lua filter key for older pandoc versions

### DIFF
--- a/pandoc/latex.yaml
+++ b/pandoc/latex.yaml
@@ -2,7 +2,7 @@ pdf-engine: xelatex
 include-in-header:
   - pandoc/header.tex
 # Luaフィルターの追加
-lua-filters:
+lua-filter:
   - pandoc/codeblock-filter.lua
 variables:
   documentclass: book


### PR DESCRIPTION
## Summary
- use `lua-filter` key in pandoc defaults

## Testing
- `pandoc --version` *(fails: command not found)*